### PR TITLE
Make UTF-8 badness go away

### DIFF
--- a/lib/readers/history_reader.rb
+++ b/lib/readers/history_reader.rb
@@ -56,7 +56,7 @@ private
   end
 
   def raw_lines
-    file_contents.split("\n")
+    file_contents.force_encoding('BINARY').split("\n")
   end
 
   def starts_with_timestamp?(line)


### PR DESCRIPTION
I don't deeply understand the details of what's UTF-8 and what encoding fails, but this fixed the following for me:

```
/Users/abesto/.rvm/gems/ruby-1.9.3-p484@global/gems/huffshell-0.0.14/lib/readers/history_reader.rb:60:in `split': invalid byte sequence in UTF-8 (ArgumentError)
    from /Users/abesto/.rvm/gems/ruby-1.9.3-p484@global/gems/huffshell-0.0.14/lib/readers/history_reader.rb:60:in `raw_lines'
    from /Users/abesto/.rvm/gems/ruby-1.9.3-p484@global/gems/huffshell-0.0.14/lib/readers/history_reader.rb:31:in `timestamps?'
    from /Users/abesto/.rvm/gems/ruby-1.9.3-p484@global/gems/huffshell-0.0.14/lib/readers/history_reader.rb:36:in `timestamps?'
    from /Users/abesto/.rvm/gems/ruby-1.9.3-p484@global/gems/huffshell-0.0.14/bin/huffshell:14:in `block in <top (required)>'
    from /Users/abesto/.rvm/gems/ruby-1.9.3-p484@global/gems/huffshell-0.0.14/bin/huffshell:12:in `each'
    from /Users/abesto/.rvm/gems/ruby-1.9.3-p484@global/gems/huffshell-0.0.14/bin/huffshell:12:in `<top (required)>'
    from /Users/abesto/.rvm/rubies/ruby-1.9.3-p484/bin/huffshell:23:in `load'
    from /Users/abesto/.rvm/rubies/ruby-1.9.3-p484/bin/huffshell:23:in `<main>'
    from /Users/abesto/.rvm/gems/ruby-1.9.3-p484/bin/ruby_executable_hooks:15:in `eval'
    from /Users/abesto/.rvm/gems/ruby-1.9.3-p484/bin/ruby_executable_hooks:15:in `<main>'
```
